### PR TITLE
Squashing silly dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "weekly"
+      
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "monthly"
+      

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -16,9 +16,9 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17 Zulu
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <jacoco.version>0.8.6</jacoco.version>
         <downloadSources>true</downloadSources>
-        <guava.version>29.0-jre</guava.version>
+        <guava.version>32.0.0-jre</guava.version>
         <buffers.version>0.0.3</buffers.version>
         <range.version>0.0.3b</range.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
-            <version>4.10.0</version>
+            <version>4.12.0</version>
         </dependency>
 
         <dependency>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>net.java.dev.jna</groupId>
             <artifactId>jna</artifactId>
-            <version>4.0.0</version>
+            <version>5.13.0</version>
         </dependency>
 
         <!-- https://search.maven.org/artifact/io.reactivex.rxjava3/rxjava/3.1.0/jar -->
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>me.friwi</groupId>
             <artifactId>jcefmaven</artifactId>
-            <version>105.3.36</version>
+            <version>116.0.19.1</version>
         </dependency>
 
 
@@ -72,21 +72,21 @@
         <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>
-            <version>1.0.3</version>
+            <version>1.0.4</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/commons-codec/commons-codec -->
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.15</version> <!-- Use 1.6 for java 1.5 -->
+            <version>1.16.0</version> <!-- Use 1.6 for java 1.5 -->
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.25</version>
+            <version>2.0.9</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -111,7 +111,7 @@
         <dependency>
             <groupId>org.eclipse.jdt</groupId>
             <artifactId>org.eclipse.jdt.annotation</artifactId>
-            <version>2.2.200</version>
+            <version>2.2.700</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
 
@@ -169,13 +169,13 @@
         <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
-            <version>1.4</version>
+            <version>1.6.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.spotbugs</groupId>
             <artifactId>spotbugs-annotations</artifactId>
-            <version>4.0.1</version>
+            <version>4.8.2</version>
         </dependency>
 
         <dependency>
@@ -256,7 +256,7 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>3.4.0</version>
 
                 <executions>
                     <execution>


### PR DESCRIPTION
Bump net.java.dev.jna:jna from 4.0.0 to 5.13.0 (#18)

Bumps [net.java.dev.jna:jna](https://github.com/java-native-access/jna) from 4.0.0 to 5.13.0.
- [Changelog](https://github.com/java-native-access/jna/blob/master/CHANGES.md)
- [Commits](https://github.com/java-native-access/jna/compare/4.0...5.13.0)

---
updated-dependencies:
- dependency-name: net.java.dev.jna:jna dependency-type: direct:production update-type: version-update:semver-major ...




Bump org.eclipse.jdt:org.eclipse.jdt.annotation from 2.2.200 to 2.2.700 (#17)

Bumps [org.eclipse.jdt:org.eclipse.jdt.annotation](https://github.com/eclipse-jdt/eclipse.jdt.core) from 2.2.200 to 2.2.700.
- [Commits](https://github.com/eclipse-jdt/eclipse.jdt.core/commits)

---
updated-dependencies:
- dependency-name: org.eclipse.jdt:org.eclipse.jdt.annotation dependency-type: direct:production update-type: version-update:semver-patch ...




Bump commons-codec:commons-codec from 1.15 to 1.16.0 (#16)

Bumps [commons-codec:commons-codec](https://github.com/apache/commons-codec) from 1.15 to 1.16.0.
- [Changelog](https://github.com/apache/commons-codec/blob/master/RELEASE-NOTES.txt)
- [Commits](https://github.com/apache/commons-codec/compare/rel/commons-codec-1.15...rel/commons-codec-1.16.0)

---
updated-dependencies:
- dependency-name: commons-codec:commons-codec dependency-type: direct:production update-type: version-update:semver-minor ...




Bump com.github.spotbugs:spotbugs-annotations from 4.0.1 to 4.8.2 (#14)

Bumps [com.github.spotbugs:spotbugs-annotations](https://github.com/spotbugs/spotbugs) from 4.0.1 to 4.8.2.
- [Release notes](https://github.com/spotbugs/spotbugs/releases)
- [Changelog](https://github.com/spotbugs/spotbugs/blob/master/CHANGELOG.md)
- [Commits](https://github.com/spotbugs/spotbugs/compare/4.0.1...4.8.2)

---
updated-dependencies:
- dependency-name: com.github.spotbugs:spotbugs-annotations dependency-type: direct:production update-type: version-update:semver-minor ...




Bump com.squareup.okhttp3:okhttp from 4.10.0 to 4.12.0 (#15)

Bumps [com.squareup.okhttp3:okhttp](https://github.com/square/okhttp) from 4.10.0 to 4.12.0.
- [Changelog](https://github.com/square/okhttp/blob/master/CHANGELOG.md)
- [Commits](https://github.com/square/okhttp/compare/parent-4.10.0...parent-4.12.0)

---
updated-dependencies:
- dependency-name: com.squareup.okhttp3:okhttp dependency-type: direct:production update-type: version-update:semver-minor ...




Bump actions/setup-java from 3 to 4 (#19)

Bumps [actions/setup-java](https://github.com/actions/setup-java) from 3 to 4.
- [Release notes](https://github.com/actions/setup-java/releases)
- [Commits](https://github.com/actions/setup-java/compare/v3...v4)

---
updated-dependencies:
- dependency-name: actions/setup-java dependency-type: direct:production update-type: version-update:semver-major ...




Bump actions/checkout from 3 to 4 (#7)

Bumps [actions/checkout](https://github.com/actions/checkout) from 3 to 4.
- [Release notes](https://github.com/actions/checkout/releases)
- [Changelog](https://github.com/actions/checkout/blob/main/CHANGELOG.md)
- [Commits](https://github.com/actions/checkout/compare/v3...v4)

---
updated-dependencies:
- dependency-name: actions/checkout dependency-type: direct:production update-type: version-update:semver-major ...




Bump org.reactivestreams:reactive-streams from 1.0.3 to 1.0.4 (#8)

Bumps [org.reactivestreams:reactive-streams](https://github.com/reactive-streams/reactive-streams) from 1.0.3 to 1.0.4.
- [Changelog](https://github.com/reactive-streams/reactive-streams-jvm/blob/master/RELEASE-NOTES.md)
- [Commits](https://github.com/reactive-streams/reactive-streams/compare/v1.0.3...v1.0.4)

---
updated-dependencies:
- dependency-name: org.reactivestreams:reactive-streams dependency-type: direct:production update-type: version-update:semver-patch ...




Bump org.codehaus.mojo:build-helper-maven-plugin from 3.2.0 to 3.4.0 (#9)

Bumps [org.codehaus.mojo:build-helper-maven-plugin](https://github.com/mojohaus/build-helper-maven-plugin) from 3.2.0 to 3.4.0.
- [Release notes](https://github.com/mojohaus/build-helper-maven-plugin/releases)
- [Commits](https://github.com/mojohaus/build-helper-maven-plugin/compare/build-helper-maven-plugin-3.2.0...3.4.0)

---
updated-dependencies:
- dependency-name: org.codehaus.mojo:build-helper-maven-plugin dependency-type: direct:production update-type: version-update:semver-minor ...




Bump me.friwi:jcefmaven from 105.3.36 to 116.0.19.1

Bumps [me.friwi:jcefmaven](https://github.com/jcefmaven/jcefmaven) from 105.3.36 to 116.0.19.1.
- [Release notes](https://github.com/jcefmaven/jcefmaven/releases)
- [Commits](https://github.com/jcefmaven/jcefmaven/compare/105.3.36...116.0.19.1)

---
updated-dependencies:
- dependency-name: me.friwi:jcefmaven dependency-type: direct:production update-type: version-update:semver-major ...



Bump org.slf4j:slf4j-simple from 1.7.25 to 2.0.9

Bumps org.slf4j:slf4j-simple from 1.7.25 to 2.0.9.

---
updated-dependencies:
- dependency-name: org.slf4j:slf4j-simple dependency-type: direct:production update-type: version-update:semver-major ...



Bump commons-cli:commons-cli from 1.4 to 1.6.0

Bumps commons-cli:commons-cli from 1.4 to 1.6.0.

---
updated-dependencies:
- dependency-name: commons-cli:commons-cli dependency-type: direct:production update-type: version-update:semver-minor ...



Create dependabot.yml

Bump com.google.guava:guava from 29.0-jre to 32.0.0-jre

Bumps [com.google.guava:guava](https://github.com/google/guava) from 29.0-jre to 32.0.0-jre.
- [Release notes](https://github.com/google/guava/releases)
- [Commits](https://github.com/google/guava/commits)

---
updated-dependencies:
- dependency-name: com.google.guava:guava dependency-type: direct:production ...



Bump junit:junit from 4.12 to 4.13.1

Bumps [junit:junit](https://github.com/junit-team/junit4) from 4.12 to 4.13.1.
- [Release notes](https://github.com/junit-team/junit4/releases)
- [Changelog](https://github.com/junit-team/junit4/blob/main/doc/ReleaseNotes4.12.md)
- [Commits](https://github.com/junit-team/junit4/compare/r4.12...r4.13.1)

---
updated-dependencies:
- dependency-name: junit:junit dependency-type: direct:development ...